### PR TITLE
Add more information for a command

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ When installing the theme using RubyGems, demo images, posts, and pages are not 
 
 1. (Optional) Create a new Jekyll site: `jekyll new my-site`
 2. Replace the current theme in your `Gemfile` with `gem "jekyll-theme-clean-blog"`.
-3. Install the theme: `bundle install`
+3. Install the theme (run the connand inside your site directory): `bundle install`
 4. Replace the current theme in your `_config.yml` file with `theme: jekyll-theme-clean-blog`.
 5. Build your site: `bundle exec jekyll serve`
 


### PR DESCRIPTION
to avoid an error; if not inside the directory of the site, when executing the command "bundle install"