### PR TITLE
Add Stackbit Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 This repository holds the official Jekyll version of the Clean Blog theme on Start Bootstrap!
 
+## Stackbit Deploy
+
+This theme is ready to import into Stackbit. This theme can be deployed to Netlify and you can connect any headless CMS including Forestry, NetlifyCMS, DatoCMS or Contentful. 
+
+[![Create with Stackbit](https://assets.stackbit.com/badge/create-with-stackbit.svg)](https://app.stackbit.com/create?theme=https://github.com/BlackrockDigital/startbootstrap-clean-blog-jekyll)
+
 ## Preview
 
 [![Clean Blog (Jekyll) Preview](https://startbootstrap.com/assets/img/screenshots/themes/clean-blog-jekyll.png)](http://blackrockdigital.github.io/startbootstrap-clean-blog-jekyll/)

--- a/_config.yml
+++ b/_config.yml
@@ -2,14 +2,14 @@ title:              Clean Blog
 email:              your-email@example.com
 description:        A Blog Theme by Start Bootstrap
 author:             Start Bootstrap
-baseurl:            "/startbootstrap-clean-blog-jekyll"
-url:                "https://blackrockdigital.github.io"
+baseurl:            ""
+url:                ""
 
 # Social Profiles
 twitter_username:   SBootstrap
 github_username:    BlackrockDigital
 facebook_username:  StartBootstrap
-linkedin_username:
+linkedin_username: ""
 
 # Add your google-analytics ID here to activate google analytics
 google_analytics:   UA-XXXXXXXXX-X # out your google-analytics code

--- a/_posts/2017-10-26-dinosaurs.md
+++ b/_posts/2017-10-26-dinosaurs.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title: "Failure is not an option"
-subtitle: "Many say exploration is part of our destiny, but it’s actually our duty to future generations."
-date: 2017-10-28 23:45:13 -0400
-background: '/img/posts/03.jpg'
+title: "Dinosaurs are extinct today"
+subtitle: "because they lacked opposable thumbs and the brainpower to build a space program."
+date: 2017-10-26T14:25:52-05:00
+background: '/img/posts/01.jpg'
 ---
 
 <p>Never in all their history have men been able truly to conceive of the world as one: a single sphere, a globe, having the qualities of a globe, a round earth in which all the directions eventually meet, in which there is no center because every point, or none, is center — an equal earth which all men occupy as equals. The airman's earth, if free men make it, will be truly round: a globe in practice, not in theory.</p>

--- a/_posts/2017-10-27-dreams.md
+++ b/_posts/2017-10-27-dreams.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "The dreams of yesterday are the hopes of today and the reality of tomorrow."
-date: 2017-10-27 23:45:13 -0400
+date: 2017-10-27T14:25:52-05:00
 background: '/img/posts/02.jpg'
 ---
 

--- a/_posts/2017-10-28-exploration.md
+++ b/_posts/2017-10-28-exploration.md
@@ -1,9 +1,9 @@
 ---
 layout: post
-title: "Dinosaurs are extinct today"
-subtitle: "because they lacked opposable thumbs and the brainpower to build a space program."
-date: 2017-10-26 23:45:13 -0400
-background: '/img/posts/01.jpg'
+title: "Failure is not an option"
+subtitle: "Many say exploration is part of our destiny, but it’s actually our duty to future generations."
+date: 2017-10-28T14:25:52-05:00
+background: '/img/posts/03.jpg'
 ---
 
 <p>Never in all their history have men been able truly to conceive of the world as one: a single sphere, a globe, having the qualities of a globe, a round earth in which all the directions eventually meet, in which there is no center because every point, or none, is center — an equal earth which all men occupy as equals. The airman's earth, if free men make it, will be truly round: a globe in practice, not in theory.</p>

--- a/_posts/2017-10-29-prophecy.md
+++ b/_posts/2017-10-29-prophecy.md
@@ -1,8 +1,9 @@
 ---
 layout: post
-title: "I believe every human has a finite number of heartbeats. I don't intend to waste any of mine."
-date: 2017-10-30 23:45:13 -0400
-background: '/img/posts/05.jpg'
+title: "Science has not yet mastered prophecy"
+subtitle: "We predict too much for the next year and yet far too little for the next ten."
+date: 2017-10-29T14:25:52-05:00
+background: '/img/posts/04.jpg'
 ---
 
 <p>Never in all their history have men been able truly to conceive of the world as one: a single sphere, a globe, having the qualities of a globe, a round earth in which all the directions eventually meet, in which there is no center because every point, or none, is center — an equal earth which all men occupy as equals. The airman's earth, if free men make it, will be truly round: a globe in practice, not in theory.</p>

--- a/_posts/2017-10-30-heartbeats.md
+++ b/_posts/2017-10-30-heartbeats.md
@@ -1,9 +1,8 @@
 ---
 layout: post
-title: "Science has not yet mastered prophecy"
-subtitle: "We predict too much for the next year and yet far too little for the next ten."
-date: 2017-10-29 23:45:13 -0400
-background: '/img/posts/04.jpg'
+title: "I believe every human has a finite number of heartbeats. I don't intend to waste any of mine."
+date: 2017-10-30T14:25:52-05:00
+background: '/img/posts/05.jpg'
 ---
 
 <p>Never in all their history have men been able truly to conceive of the world as one: a single sphere, a globe, having the qualities of a globe, a round earth in which all the directions eventually meet, in which there is no center because every point, or none, is center — an equal earth which all men occupy as equals. The airman's earth, if free men make it, will be truly round: a globe in practice, not in theory.</p>

--- a/_posts/2017-10-31-man-must-explore.md
+++ b/_posts/2017-10-31-man-must-explore.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Man must explore, and this is exploration at its greatest"
 subtitle: "Problems look mighty small from 150 miles up"
-date: 2017-10-31 10:45:13 -0400
+date: 2017-10-31T14:25:52-05:00
 background: '/img/posts/06.jpg'
 ---
 

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -1,0 +1,165 @@
+stackbitVersion: ~0.2.0
+ssgName: custom
+publishDir: _site
+buildCommand: bundle install && bundle exec jekyll build
+uploadDir: img
+staticDir: ""
+pagesDir: ""
+dataDir: ""
+models:
+  config:
+    type: data
+    label: Config
+    file: _config.yml
+    fields:
+      - type: string
+        name: title
+        label: Title
+        required: true
+      - type: string
+        name: email
+        label: Email
+      - type: string
+        name: description
+        label: Description
+      - type: string
+        name: author
+        label: Author name
+      - type: string
+        name: description
+        label: Description
+      - type: string
+        name: baseurl
+        label: Base URL
+        description: the subpath of your site, e.g. /blog/
+      - type: string
+        name: url
+        label: URL
+        description: the base hostname & protocol for your site
+      - type: string
+        name: twitter_username
+        label: Twitter Username
+      - type: string
+        name: github_username
+        label: Github Username
+      - type: string
+        name: facebook_username
+        label: Facebook Username
+      - type: string
+        name: linkedin_username
+        label: Linkein Username
+      - type: string
+        name: google_analytics
+        label: Google Analytics Code
+      - type: string
+        name: markdown
+        label: Markdown
+      - type: number
+        name: paginate
+        label: Paginate per page
+      - type: string
+        name: paginate_path
+        label: Paginate Path
+      - type: list
+        name: plugins
+        label: Plugins
+        items:
+          type: string
+  home:
+    type: page
+    label: Home Page
+    file: index.html
+    singleInstance: true
+    fields:
+      - type: string
+        name: layout
+        label: Layout
+        const: home
+      - type: image
+        name: background
+        label: Background
+  about:
+    type: page
+    label: About Page
+    file: about.html
+    singleInstance: true
+    fields:
+      - type: string
+        name: layout
+        label: Layout
+        const: page
+      - type: string
+        name: title
+        label: Page Title
+      - type: string
+        name: description
+        label: Page Description
+      - type: image
+        name: background
+        label: Background
+  contact:
+    type: page
+    label: Contact Page
+    file: contact.html
+    singleInstance: true
+    fields:
+      - type: string
+        name: layout
+        label: Layout
+        const: page
+      - type: string
+        name: title
+        label: Page Title
+      - type: string
+        name: description
+        label: Page Description
+      - type: image
+        name: background
+        label: Background
+      - type: boolean
+        name: form
+        label: Form
+  posts:
+    type: page
+    label: Post List Page
+    file: posts/index.html
+    singleInstance: true
+    fields:
+      - type: string
+        name: layout
+        label: Layout
+        const: page
+      - type: string
+        name: title
+        label: Page Title
+      - type: image
+        name: background
+        label: Background
+  post:
+    type: page
+    label: Post
+    folder: _posts
+    fields:
+      - type: string
+        name: layout
+        label: Layout
+        const: post
+      - type: string
+        name: title
+        label: Page Title 
+      - type: string
+        name: subtitle
+        label: Subtitle
+      - type: date
+        name: date
+        label: Publish Date
+      - type: image
+        name: background
+        label: Background
+
+
+
+
+
+
+

--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -20,9 +20,6 @@ models:
         name: email
         label: Email
       - type: string
-        name: description
-        label: Description
-      - type: string
         name: author
         label: Author name
       - type: string


### PR DESCRIPTION
This pull request add's Stackbit to this Jekyll theme. It add's the stackbit.yaml file which makes this theme work with several headless CMS automatically (including Forestry, NetlifyCMS, DatoCMS & Contentful) and it deploys the site to Netlify in 1 click.

You can try it out: https://app.stackbit.com/create?theme=https://github.com/stackbithq/startbootstrap-clean-blog-jekyll (note the "create with stackbit" button in the readme will import the theme from your repo so until the PR is merged it wont work)

I think this is really valuable and is a very low impact addition on your existing theme structure. Pretty much just the stackbit.yaml file. If you have questions or feedback I'm happy to discuss.

Darko