### PR TITLE
Update the contact form to work with Formspree free accounts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,25 +68,25 @@ Assuming there are no errors and the site is building properly, follow these ste
 5. Add the form to the `contact.html` page. Add the following code to your `contact.html` page:
 
     ```html
-    <form name="sentMessage" id="contactForm" novalidate>
+    <form id="contactform" name="sentMessage" id="contactForm" action="https://formspree.io/{{ site.email }}" method="POST">
       <div class="control-group">
         <div class="form-group floating-label-form-group controls">
           <label>Name</label>
-          <input type="text" class="form-control" placeholder="Name" id="name" required data-validation-required-message="Please enter your name.">
+          <input type="text" name="name" class="form-control" placeholder="Name" id="name" required data-validation-required-message="Please enter your name.">
           <p class="help-block text-danger"></p>
         </div>
       </div>
       <div class="control-group">
         <div class="form-group floating-label-form-group controls">
           <label>Email Address</label>
-          <input type="email" class="form-control" placeholder="Email Address" id="email" required data-validation-required-message="Please enter your email address.">
+          <input type="email" name="email" class="form-control" placeholder="Email Address" id="email" required data-validation-required-message="Please enter your email address.">
           <p class="help-block text-danger"></p>
         </div>
       </div>
       <div class="control-group">
         <div class="form-group col-xs-12 floating-label-form-group controls">
           <label>Phone Number</label>
-          <input type="tel" class="form-control" placeholder="Phone Number" id="phone" required data-validation-required-message="Please enter your phone number.">
+          <input type="tel" name="phone" class="form-control" placeholder="Phone Number" id="phone" required data-validation-required-message="Please enter your phone number.">
           <p class="help-block text-danger"></p>
         </div>
       </div>
@@ -97,10 +97,19 @@ Assuming there are no errors and the site is building properly, follow these ste
           <p class="help-block text-danger"></p>
         </div>
       </div>
+        <!--the following are optional fields to customize how submissions are processed-->
+        <!--The first sets the subject of Formspree notification emails.-->
+        <!--The second catches (some) spambots.-->
+    
+      <!-- <input type="hidden" name="_subject" value="Sent from your blog contact form." /> -->
+      <!-- <input type="text" name="_gotcha" style="display:none" /> -->
+    
+        <!--End of optional fields.-->
+    
       <br>
       <div id="success"></div>
       <div class="form-group">
-        <button type="submit" class="btn btn-primary" id="sendMessageButton">Send</button>
+        <input type="submit" class="btn btn-primary" value="Send">
       </div>
     </form>
     ```

--- a/contact.html
+++ b/contact.html
@@ -5,27 +5,26 @@ description: Have questions? I have answers.
 background: '/img/bg-contact.jpg'
 form: true
 ---
-
 <p>Want to get in touch? Fill out the form below to send me a message and I will get back to you as soon as possible!</p>
-<form name="sentMessage" id="contactForm" novalidate>
+<form id="contactform" name="sentMessage" id="contactForm" action="https://formspree.io/{{ site.email }}" method="POST">
   <div class="control-group">
     <div class="form-group floating-label-form-group controls">
       <label>Name</label>
-      <input type="text" class="form-control" placeholder="Name" id="name" required data-validation-required-message="Please enter your name.">
+      <input type="text" name="name" class="form-control" placeholder="Name" id="name" required data-validation-required-message="Please enter your name.">
       <p class="help-block text-danger"></p>
     </div>
   </div>
   <div class="control-group">
     <div class="form-group floating-label-form-group controls">
       <label>Email Address</label>
-      <input type="email" class="form-control" placeholder="Email Address" id="email" required data-validation-required-message="Please enter your email address.">
+      <input type="email" name="email" class="form-control" placeholder="Email Address" id="email" required data-validation-required-message="Please enter your email address.">
       <p class="help-block text-danger"></p>
     </div>
   </div>
   <div class="control-group">
     <div class="form-group col-xs-12 floating-label-form-group controls">
       <label>Phone Number</label>
-      <input type="tel" class="form-control" placeholder="Phone Number" id="phone" required data-validation-required-message="Please enter your phone number.">
+      <input type="tel" name="phone" class="form-control" placeholder="Phone Number" id="phone" required data-validation-required-message="Please enter your phone number.">
       <p class="help-block text-danger"></p>
     </div>
   </div>
@@ -36,9 +35,18 @@ form: true
       <p class="help-block text-danger"></p>
     </div>
   </div>
+    <!--the following are optional fields to customize how submissions are processed-->
+    <!--The first sets the subject of Formspree notification emails.-->
+    <!--The second catches (some) spambots.-->
+
+  <!-- <input type="hidden" name="_subject" value="Sent from blog Contact form." /> -->
+  <!-- <input type="text" name="_gotcha" style="display:none" /> -->
+
+    <!--End of optional fields.-->
+
   <br>
   <div id="success"></div>
   <div class="form-group">
-    <button type="submit" class="btn btn-primary" id="sendMessageButton">Send</button>
+    <input type="submit" class="btn btn-primary" value="Send">
   </div>
 </form>


### PR DESCRIPTION
I updated the form to match current Formspree specs to the best of my knowledge.
* updated form attributes & linked to {{ site.email }} as implied
* added name values to inputs
* changed button element to input class .btn

Notably, this breaks the nice success pop-up since we get redirected to a reCaptcha now. Otherwise the form should be functionally identical.

I also added a couple extra hidden elements in comments in case someone wants to try them. Finally, I updated the README code snippet to reflect changes.